### PR TITLE
Add Turbo Controller WinForms app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # AI
+
+This repository now contains a Windows turbo controller example built with .NET 6.0 and WinForms. The application lives in the `TurboController/` directory and includes scripts and documentation to build and publish a Windows executable.

--- a/TurboController/MainForm.cs
+++ b/TurboController/MainForm.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace TurboController
+{
+    public partial class MainForm : Form
+    {
+        private readonly Dictionary<string, ushort> _virtualKeys = new()
+        {
+            { "Left Mouse", 0x01 },
+            { "Right Mouse", 0x02 },
+            { "Middle Mouse", 0x04 },
+            { "Space", 0x20 },
+            { "Tab", 0x09 },
+            { "Enter", 0x0D },
+            { "Shift", 0x10 },
+            { "Ctrl", 0x11 },
+            { "Alt", 0x12 },
+            { "Q", 0x51 },
+            { "E", 0x45 },
+            { "R", 0x52 },
+            { "F", 0x46 },
+            { "1", 0x31 },
+            { "2", 0x32 },
+            { "3", 0x33 },
+            { "4", 0x34 },
+            { "5", 0x35 },
+            { "6", 0x36 },
+        };
+
+        private readonly Dictionary<string, ushort> _triggerKeys = new()
+        {
+            { "Left Mouse", 0x01 },
+            { "Right Mouse", 0x02 },
+            { "Middle Mouse", 0x04 },
+            { "Ctrl", 0x11 },
+            { "Shift", 0x10 },
+            { "Alt", 0x12 },
+            { "Space", 0x20 },
+            { "Tab", 0x09 },
+            { "Caps Lock", 0x14 },
+            { "Q", 0x51 },
+            { "E", 0x45 },
+            { "R", 0x52 },
+            { "F", 0x46 },
+        };
+
+        private const int HotkeyId = 1;
+        private const uint ModAlt = 0x1;
+        private const uint ModControl = 0x2;
+        private const int WmHotkey = 0x0312;
+
+        private readonly NotifyIcon _trayIcon;
+        private readonly ContextMenuStrip _trayMenu;
+        private CancellationTokenSource? _cancellationSource;
+        private Task? _turboTask;
+        private bool _turboEnabled;
+
+        private Label _statusLabel = null!;
+        private ComboBox _triggerSelect = null!;
+        private ComboBox _virtualSelect = null!;
+        private TrackBar _speedSlider = null!;
+        private NumericUpDown _speedNumeric = null!;
+        private Button _startButton = null!;
+        private Button _stopButton = null!;
+        private Button _aboutButton = null!;
+
+        public MainForm()
+        {
+            InitializeComponent();
+
+            _trayMenu = new ContextMenuStrip();
+            _trayMenu.Items.Add("Toggle Turbo", null, (_, _) => ToggleTurbo());
+            _trayMenu.Items.Add("Exit", null, (_, _) => Application.Exit());
+
+            _trayIcon = new NotifyIcon
+            {
+                Icon = SystemIcons.Application,
+                Visible = true,
+                Text = "Turbo Controller",
+                ContextMenuStrip = _trayMenu
+            };
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            RegisterHotkey();
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            base.OnFormClosing(e);
+            UnregisterHotkey();
+            StopTurbo();
+            _trayIcon.Visible = false;
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WmHotkey && m.WParam.ToInt32() == HotkeyId)
+            {
+                ToggleTurbo();
+            }
+
+            base.WndProc(ref m);
+        }
+
+        private void InitializeComponent()
+        {
+            Text = "Turbo Controller";
+            MinimumSize = new Size(480, 380);
+            StartPosition = FormStartPosition.CenterScreen;
+
+            var header = new Label
+            {
+                Text = "Turbo Controller",
+                Font = new Font("Segoe UI", 16, FontStyle.Bold),
+                AutoSize = true,
+                Location = new Point(20, 15)
+            };
+
+            var description = new Label
+            {
+                Text = "Hold a trigger key to auto-press a virtual key. Toggle globally with Ctrl+Alt+T.",
+                AutoSize = true,
+                MaximumSize = new Size(420, 0),
+                Location = new Point(20, 50)
+            };
+
+            _statusLabel = new Label
+            {
+                Text = "Status: Idle",
+                AutoSize = true,
+                ForeColor = Color.DarkRed,
+                Font = new Font("Segoe UI", 10, FontStyle.Bold),
+                Location = new Point(20, 85)
+            };
+
+            var triggerLabel = new Label
+            {
+                Text = "Trigger button (hold):",
+                AutoSize = true,
+                Location = new Point(20, 120)
+            };
+
+            _triggerSelect = new ComboBox
+            {
+                Location = new Point(200, 115),
+                Width = 200,
+                DropDownStyle = ComboBoxStyle.DropDownList
+            };
+            _triggerSelect.Items.AddRange(new List<string>(_triggerKeys.Keys).ToArray());
+            _triggerSelect.SelectedIndex = 0;
+
+            var virtualLabel = new Label
+            {
+                Text = "Virtual button (sent):",
+                AutoSize = true,
+                Location = new Point(20, 155)
+            };
+
+            _virtualSelect = new ComboBox
+            {
+                Location = new Point(200, 150),
+                Width = 200,
+                DropDownStyle = ComboBoxStyle.DropDownList
+            };
+            _virtualSelect.Items.AddRange(new List<string>(_virtualKeys.Keys).ToArray());
+            _virtualSelect.SelectedIndex = 3; // Space
+
+            var speedLabel = new Label
+            {
+                Text = "Turbo speed (ms):",
+                AutoSize = true,
+                Location = new Point(20, 190)
+            };
+
+            _speedSlider = new TrackBar
+            {
+                Minimum = 10,
+                Maximum = 200,
+                TickFrequency = 10,
+                Value = 60,
+                Location = new Point(200, 185),
+                Width = 200
+            };
+            _speedSlider.ValueChanged += (_, _) => _speedNumeric.Value = _speedSlider.Value;
+
+            _speedNumeric = new NumericUpDown
+            {
+                Minimum = 10,
+                Maximum = 200,
+                Increment = 5,
+                Value = 60,
+                Location = new Point(410, 185),
+                Width = 60
+            };
+            _speedNumeric.ValueChanged += (_, _) => _speedSlider.Value = (int)_speedNumeric.Value;
+
+            _startButton = new Button
+            {
+                Text = "Start (Ctrl+Alt+T)",
+                Location = new Point(20, 235),
+                Width = 180,
+                Height = 35,
+                BackColor = Color.FromArgb(0, 122, 204),
+                ForeColor = Color.White
+            };
+            _startButton.Click += (_, _) => StartTurbo();
+
+            _stopButton = new Button
+            {
+                Text = "Stop",
+                Location = new Point(210, 235),
+                Width = 90,
+                Height = 35,
+                Enabled = false
+            };
+            _stopButton.Click += (_, _) => StopTurbo();
+
+            _aboutButton = new Button
+            {
+                Text = "About",
+                Location = new Point(310, 235),
+                Width = 90,
+                Height = 35
+            };
+            _aboutButton.Click += (_, _) => ShowAbout();
+
+            var minimizeButton = new Button
+            {
+                Text = "Minimize to tray",
+                Location = new Point(20, 280),
+                Width = 180,
+                Height = 30
+            };
+            minimizeButton.Click += (_, _) =>
+            {
+                Hide();
+                _trayIcon.ShowBalloonTip(1500, "Turbo Controller", "Running in the background.", ToolTipIcon.Info);
+            };
+
+            Controls.AddRange(new Control[]
+            {
+                header, description, _statusLabel, triggerLabel, _triggerSelect, virtualLabel,
+                _virtualSelect, speedLabel, _speedSlider, _speedNumeric, _startButton,
+                _stopButton, _aboutButton, minimizeButton
+            });
+        }
+
+        private void RegisterHotkey()
+        {
+            if (!RegisterHotKey(Handle, HotkeyId, ModControl | ModAlt, (int)Keys.T))
+            {
+                MessageBox.Show("Unable to register hotkey Ctrl+Alt+T", "Hotkey", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        private void UnregisterHotkey()
+        {
+            UnregisterHotKey(Handle, HotkeyId);
+        }
+
+        private void ToggleTurbo()
+        {
+            if (_turboEnabled)
+            {
+                StopTurbo();
+            }
+            else
+            {
+                StartTurbo();
+            }
+        }
+
+        private void StartTurbo()
+        {
+            if (_turboEnabled)
+            {
+                return;
+            }
+
+            _turboEnabled = true;
+            _statusLabel.Text = "Status: Active";
+            _statusLabel.ForeColor = Color.ForestGreen;
+            _startButton.Enabled = false;
+            _stopButton.Enabled = true;
+
+            _cancellationSource = new CancellationTokenSource();
+            _turboTask = Task.Run(() => RunTurboLoop(_cancellationSource.Token));
+        }
+
+        private void StopTurbo()
+        {
+            if (!_turboEnabled)
+            {
+                return;
+            }
+
+            _turboEnabled = false;
+            _statusLabel.Text = "Status: Idle";
+            _statusLabel.ForeColor = Color.DarkRed;
+            _startButton.Enabled = true;
+            _stopButton.Enabled = false;
+
+            _cancellationSource?.Cancel();
+            _turboTask = null;
+        }
+
+        private void RunTurboLoop(CancellationToken token)
+        {
+            var triggerKey = _triggerKeys[(string)_triggerSelect.InvokeUi(() => _triggerSelect.SelectedItem!)];
+            var virtualKey = _virtualKeys[(string)_virtualSelect.InvokeUi(() => _virtualSelect.SelectedItem!)];
+
+            while (!token.IsCancellationRequested)
+            {
+                if (IsTriggerPressed(triggerKey))
+                {
+                    SendTurboKey(virtualKey);
+                }
+                Thread.Sleep(5);
+            }
+        }
+
+        private void SendTurboKey(ushort key)
+        {
+            int delay;
+            try
+            {
+                delay = (int)_speedNumeric.InvokeUi(() => _speedNumeric.Value);
+            }
+            catch (InvalidOperationException)
+            {
+                delay = 60;
+            }
+
+            var down = new INPUT
+            {
+                type = InputType.INPUT_KEYBOARD,
+                U = new InputUnion { ki = new KEYBDINPUT { wVk = key } }
+            };
+
+            var up = new INPUT
+            {
+                type = InputType.INPUT_KEYBOARD,
+                U = new InputUnion { ki = new KEYBDINPUT { wVk = key, dwFlags = 0x0002 } }
+            };
+
+            SendInput(1, new[] { down }, Marshal.SizeOf<INPUT>());
+            Thread.Sleep(delay);
+            SendInput(1, new[] { up }, Marshal.SizeOf<INPUT>());
+            Thread.Sleep(delay);
+        }
+
+        private bool IsTriggerPressed(ushort key)
+        {
+            short state = GetAsyncKeyState(key);
+            return (state & 0x8000) != 0;
+        }
+
+        private void ShowAbout()
+        {
+            var info = "Turbo Controller\n" +
+                       "- Hold a trigger key to repeatedly send a virtual key.\n" +
+                       "- Adjust speed between 10-200ms.\n" +
+                       "- Use Ctrl+Alt+T to toggle anywhere.";
+            MessageBox.Show(info, "About", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        #region Win32
+
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, int vk);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INPUT
+        {
+            public InputType type;
+            public InputUnion U;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct InputUnion
+        {
+            [FieldOffset(0)] public MOUSEINPUT mi;
+            [FieldOffset(0)] public KEYBDINPUT ki;
+            [FieldOffset(0)] public HARDWAREINPUT hi;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MOUSEINPUT
+        {
+            public int dx;
+            public int dy;
+            public int mouseData;
+            public int dwFlags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KEYBDINPUT
+        {
+            public ushort wVk;
+            public ushort wScan;
+            public uint dwFlags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct HARDWAREINPUT
+        {
+            public int uMsg;
+            public short wParamL;
+            public short wParamH;
+        }
+
+        private enum InputType
+        {
+            INPUT_MOUSE = 0,
+            INPUT_KEYBOARD = 1,
+            INPUT_HARDWARE = 2
+        }
+
+        #endregion
+    }
+
+    internal static class ControlExtensions
+    {
+        public static T InvokeUi<T>(this Control control, Func<T> func)
+        {
+            if (control.InvokeRequired)
+            {
+                return (T)control.Invoke(func);
+            }
+            return func();
+        }
+    }
+}

--- a/TurboController/MainForm.cs
+++ b/TurboController/MainForm.cs
@@ -340,22 +340,66 @@ namespace TurboController
                 delay = 60;
             }
 
-            var down = new INPUT
+            if (TryGetMouseFlags(key, out var downFlag, out var upFlag))
+            {
+                var down = new INPUT
+                {
+                    type = InputType.INPUT_MOUSE,
+                    U = new InputUnion { mi = new MOUSEINPUT { dwFlags = downFlag } }
+                };
+
+                var up = new INPUT
+                {
+                    type = InputType.INPUT_MOUSE,
+                    U = new InputUnion { mi = new MOUSEINPUT { dwFlags = upFlag } }
+                };
+
+                SendInput(1, new[] { down }, Marshal.SizeOf<INPUT>());
+                Thread.Sleep(delay);
+                SendInput(1, new[] { up }, Marshal.SizeOf<INPUT>());
+                Thread.Sleep(delay);
+                return;
+            }
+
+            var keyDown = new INPUT
             {
                 type = InputType.INPUT_KEYBOARD,
                 U = new InputUnion { ki = new KEYBDINPUT { wVk = key } }
             };
 
-            var up = new INPUT
+            var keyUp = new INPUT
             {
                 type = InputType.INPUT_KEYBOARD,
                 U = new InputUnion { ki = new KEYBDINPUT { wVk = key, dwFlags = 0x0002 } }
             };
 
-            SendInput(1, new[] { down }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { keyDown }, Marshal.SizeOf<INPUT>());
             Thread.Sleep(delay);
-            SendInput(1, new[] { up }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { keyUp }, Marshal.SizeOf<INPUT>());
             Thread.Sleep(delay);
+        }
+
+        private static bool TryGetMouseFlags(ushort key, out int downFlag, out int upFlag)
+        {
+            switch (key)
+            {
+                case 0x01: // VK_LBUTTON
+                    downFlag = 0x0002; // MOUSEEVENTF_LEFTDOWN
+                    upFlag = 0x0004;   // MOUSEEVENTF_LEFTUP
+                    return true;
+                case 0x02: // VK_RBUTTON
+                    downFlag = 0x0008; // MOUSEEVENTF_RIGHTDOWN
+                    upFlag = 0x0010;   // MOUSEEVENTF_RIGHTUP
+                    return true;
+                case 0x04: // VK_MBUTTON
+                    downFlag = 0x0020; // MOUSEEVENTF_MIDDLEDOWN
+                    upFlag = 0x0040;   // MOUSEEVENTF_MIDDLEUP
+                    return true;
+                default:
+                    downFlag = 0;
+                    upFlag = 0;
+                    return false;
+            }
         }
 
         private bool IsTriggerPressed(ushort key)

--- a/TurboController/OVERVIEW.md
+++ b/TurboController/OVERVIEW.md
@@ -1,0 +1,8 @@
+# Overview
+
+Turbo Controller is a lightweight WinForms utility for Windows that repeatedly sends a chosen virtual key while you hold a trigger key. It uses native Win32 APIs to keep latency low and registers a global hotkey so you can toggle turbo from any window.
+
+- **UI stack:** .NET 6.0, WinForms
+- **Entry point:** `Program.cs`
+- **Main logic:** `MainForm.cs` (UI, hotkey registration, turbo loop, Win32 interop)
+- **Build script:** `build.bat` (Release publish to `published/`)

--- a/TurboController/Program.cs
+++ b/TurboController/Program.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Windows.Forms;
+
+namespace TurboController
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/TurboController/QUICKSTART.md
+++ b/TurboController/QUICKSTART.md
@@ -1,0 +1,12 @@
+# Quickstart
+
+1. Install the **.NET 6.0 SDK** (or newer) on Windows.
+2. From a Developer Command Prompt, run:
+   ```cmd
+   dotnet restore
+   dotnet publish -c Release -r win-x64 --self-contained false -o published
+   ```
+3. Launch `published/TurboController.exe`.
+4. Choose your trigger/virtual buttons, set speed, and press **Ctrl+Alt+T** to toggle.
+
+You can also double-click `build.bat`, which runs the publish command and drops the output into `published/`.

--- a/TurboController/README.md
+++ b/TurboController/README.md
@@ -1,0 +1,26 @@
+# Turbo Controller
+
+A Windows application that sends rapid virtual key presses whenever you hold a chosen trigger key. Designed for simple turbo/tap firing without sacrificing responsiveness.
+
+## Features
+- **Global hotkey**: toggle turbo anywhere with **Ctrl+Alt+T**
+- **Trigger vs. virtual buttons**: 13 trigger options and 12 virtual buttons
+- **Turbo speed control**: 10–200 ms between press/release
+- **System tray**: minimize to tray with quick balloon reminder
+- **Responsive UI**: async loop so the form stays responsive
+- **Win32 accuracy**: uses `SendInput`, `GetAsyncKeyState`, and `RegisterHotKey`
+
+## Usage
+1. Choose a **Trigger button** (what you hold).
+2. Choose a **Virtual button** (what the app will press).
+3. Set **Turbo speed (ms)** via slider or numeric input.
+4. Click **Start** or press **Ctrl+Alt+T** to enable.
+5. Hold your trigger key to send repeated presses of the virtual key.
+6. Click **Stop** or use **Ctrl+Alt+T** again to pause.
+
+## Tray controls
+- **Minimize to tray** keeps turbo running in the background.
+- Tray menu offers **Toggle Turbo** and **Exit** shortcuts.
+
+## Safety note
+Be mindful of game/service terms of use when automating input.

--- a/TurboController/TurboController.csproj
+++ b/TurboController/TurboController.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/TurboController/build.bat
+++ b/TurboController/build.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+if not exist published mkdir published
+
+dotnet restore
+if %errorlevel% neq 0 goto :error
+
+dotnet publish -c Release -r win-x64 --self-contained false -o published
+if %errorlevel% neq 0 goto :error
+
+echo.
+echo Publish complete. Launch published\TurboController.exe
+exit /b 0
+
+:error
+echo Build failed.
+exit /b 1


### PR DESCRIPTION
## Summary
- add a WinForms-based Turbo Controller utility with trigger/virtual key selection, speed controls, and global hotkey support
- integrate tray controls, turbo loop using Win32 input APIs, and UI affordances for start/stop
- provide build script and documentation (overview, quickstart, project README) and update root readme

## Testing
- not run (Windows-targeted build environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e69eebd88326b51e67fb9636b62e)